### PR TITLE
Removed `Random a` constraint on `liftRand` and `liftRandT`.

### DIFF
--- a/Control/Monad/Random.hs
+++ b/Control/Monad/Random.hs
@@ -121,7 +121,7 @@ runRandT  :: (Monad m, RandomGen g) => RandT g m a -> g -> m (a, g)
 runRandT (RandT x) g = runStateT x g
 
 -- | A basic random monad.
-type Rand g a = RandT g Identity a
+type Rand g = RandT g Identity
 
 -- | Evaluate a random computation using the generator @g@.  Note that the
 -- generator @g@ is not returned, so there's no way to recover the


### PR DESCRIPTION
The main reason, it seems, for users to need these lift functions is so
they can custom-generate from random-generators values when there is _no_ `Random`
instance. The previous constraint verily prevents that, though it does not really
need the constraint for its own implementation.
