### PR TITLE
Unconditionally add ErrorT and ExceptT instances using mtl-compat

### DIFF
--- a/Control/Monad/Random.hs
+++ b/Control/Monad/Random.hs
@@ -50,11 +50,8 @@ import           Control.Applicative
 import           Control.Arrow
 import           Control.Monad                ()
 import           Control.Monad.Cont
-#if MIN_VERSION_transformers(0,4,0)
 import           Control.Monad.Except
-#else
 import           Control.Monad.Error
-#endif
 import           Control.Monad.Identity
 import           Control.Monad.Random.Class
 import           Control.Monad.Reader
@@ -203,11 +200,13 @@ instance (MonadRandom m, Monoid w) => MonadRandom (RWSS.RWST r w s m) where
     getRandoms = lift getRandoms
     getRandomRs = lift . getRandomRs
 
-#if MIN_VERSION_transformers(0,4,0)
 instance (MonadRandom m) => MonadRandom (ExceptT e m) where
-#else
+    getRandom = lift getRandom
+    getRandomR = lift . getRandomR
+    getRandoms = lift getRandoms
+    getRandomRs = lift . getRandomRs
+
 instance (Error e, MonadRandom m) => MonadRandom (ErrorT e m) where
-#endif
     getRandom = lift getRandom
     getRandomR = lift . getRandomR
     getRandoms = lift getRandoms
@@ -249,11 +248,10 @@ instance (MonadSplit g m, Monoid w) => MonadSplit g (RWSL.RWST r w s m) where
 instance (MonadSplit g m, Monoid w) => MonadSplit g (RWSS.RWST r w s m) where
     getSplit = lift getSplit
 
-#if MIN_VERSION_transformers(0,4,0)
 instance (MonadSplit g m) => MonadSplit g (ExceptT e m) where
-#else
+    getSplit = lift getSplit
+
 instance (Error e, MonadSplit g m) => MonadSplit g (ErrorT e m) where
-#endif
     getSplit = lift getSplit
 
 instance (MonadSplit g m) => MonadSplit g (MaybeT m) where

--- a/Control/Monad/Random.hs
+++ b/Control/Monad/Random.hs
@@ -50,7 +50,6 @@ import           Control.Applicative
 import           Control.Arrow
 import           Control.Monad                ()
 import           Control.Monad.Cont
-import           Control.Monad.Except
 import           Control.Monad.Error
 import           Control.Monad.Identity
 import           Control.Monad.Random.Class
@@ -61,6 +60,7 @@ import           Control.Monad.State
 import qualified Control.Monad.State.Lazy     as SL
 import qualified Control.Monad.State.Strict   as SS
 import           Control.Monad.Trans          ()
+import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Identity
 import           Control.Monad.Trans.Maybe
 import           Control.Monad.Writer.Class

--- a/MonadRandom.cabal
+++ b/MonadRandom.cabal
@@ -17,6 +17,6 @@ source-repository head
 
 library
   exposed-modules:     Control.Monad.Random, Control.Monad.Random.Class
-  build-depends:       base >= 2 && < 5, transformers >= 0.3 && < 0.5, mtl, mtl-compat == 0.1.*, random
+  build-depends:       base >= 2 && < 5, transformers >= 0.3 && < 0.5, transformers-compat == 0.4.*, mtl, random
   ghc-options:         -Wall
   default-language:    Haskell2010

--- a/MonadRandom.cabal
+++ b/MonadRandom.cabal
@@ -17,6 +17,6 @@ source-repository head
 
 library
   exposed-modules:     Control.Monad.Random, Control.Monad.Random.Class
-  build-depends:       base >= 2 && < 5, transformers >= 0.3 && < 0.5, mtl, random
+  build-depends:       base >= 2 && < 5, transformers >= 0.3 && < 0.5, mtl, mtl-compat == 0.1.*, random
   ghc-options:         -Wall
   default-language:    Haskell2010


### PR DESCRIPTION
This is needed to allow reverse-dependencies of this package to migrate to `ExceptT` while keeping backwards compatibility for older versions of `mtl`.

There is also no need to remove the ErrorT instance when using newer versions of mtl/transformers since they still provide ErrorT. 

Also see https://github.com/fpco/stackage/issues/439
