### PR TITLE
Add safe uniform distribution.

### DIFF
--- a/Control/Monad/Random.hs
+++ b/Control/Monad/Random.hs
@@ -39,6 +39,7 @@ module Control.Monad.Random (
     evalRandIO,
     fromList,
     uniform,
+    uniformMay,
     Rand, RandT, -- but not the data constructors
     -- * Special lift functions
     liftRand,
@@ -148,6 +149,11 @@ fromList xs = do
 -- | Sample a value from a uniform distribution of a list of elements.
 uniform :: (MonadRandom m) => [a] -> m a
 uniform = fromList . fmap (flip (,) 1)
+
+-- | Sample a value from a uniform distribution of a list of elements if that list is not empty.
+uniformMay :: (MonadRandom m) => [a] -> m (Maybe a)
+uniformMay [] = Nothing
+uniformMay xs = fmap Just (uniform xs)
 
 instance (MonadRandom m) => MonadRandom (IdentityT m) where
     getRandom = lift getRandom

--- a/Control/Monad/Random.hs
+++ b/Control/Monad/Random.hs
@@ -152,7 +152,7 @@ uniform = fromList . fmap (flip (,) 1)
 
 -- | Sample a value from a uniform distribution of a list of elements if that list is not empty.
 uniformMay :: (MonadRandom m) => [a] -> m (Maybe a)
-uniformMay [] = Nothing
+uniformMay [] = return Nothing
 uniformMay xs = fmap Just (uniform xs)
 
 instance (MonadRandom m) => MonadRandom (IdentityT m) where

--- a/Control/Monad/Random.hs
+++ b/Control/Monad/Random.hs
@@ -153,7 +153,7 @@ uniform = fromList . fmap (flip (,) 1)
 -- | Sample a value from a uniform distribution of a list of elements if that list is not empty.
 uniformMay :: (MonadRandom m) => [a] -> m (Maybe a)
 uniformMay [] = return Nothing
-uniformMay xs = fmap Just (uniform xs)
+uniformMay xs = liftM Just (uniform xs)
 
 instance (MonadRandom m) => MonadRandom (IdentityT m) where
     getRandom = lift getRandom


### PR DESCRIPTION
This combination of `uniform` and the principle that begets the [`safe`](https://hackage.haskell.org/package/safe) package ought to go in here because that package shouldn't have a dependency on this one.