### PR TITLE
Generalize samplers to Foldable

### DIFF
--- a/Control/Monad/Random.hs
+++ b/Control/Monad/Random.hs
@@ -69,6 +69,7 @@ import           Control.Monad.Writer.Class
 import qualified Control.Monad.Writer.Lazy    as WL
 import qualified Control.Monad.Writer.Strict  as WS
 import           Data.Monoid                  (Monoid)
+import qualified Data.Foldable                as F
 import           System.Random
 
 -- | A monad transformer which adds a random number generator to an
@@ -133,27 +134,29 @@ runRand x g = runIdentity (runRandT x g)
 evalRandIO :: Rand StdGen a -> IO a
 evalRandIO x = fmap (evalRand x) newStdGen
 
--- | Sample a random value from a weighted list.  The total weight of all
+-- | Sample a random value from a weighted Foldable. The total weight of all
 -- elements must not be 0.
-fromList :: (MonadRandom m) => [(a,Rational)] -> m a
-fromList [] = error "MonadRandom.fromList called with empty list"
-fromList [(x,_)] = return x
-fromList xs = do
-  -- TODO: Do we want to be able to use floats as weights?
-  -- TODO: Better error message if weights sum to 0.
-  let s = (fromRational (sum (map snd xs))) :: Double -- total weight
-      cs = scanl1 (\(_,q) (y,s') -> (y, s'+q)) xs       -- cumulative weight
-  p <- liftM toRational $ getRandomR (0.0,s)
-  return . fst . head $ dropWhile (\(_,q) -> q < p) cs
+fromList :: (F.Foldable t, MonadRandom m) => t (a,Rational) -> m a
+fromList = fromList' . F.toList where
+  fromList' [] = error "MonadRandom.fromList called with empty list"
+  fromList' [(x,_)] = return x
+  fromList' xs = do
+    -- TODO: Do we want to be able to use floats as weights?
+    -- TODO: Better error message if weights sum to 0.
+    let s = (fromRational (sum (map snd xs))) :: Double -- total weight
+        cs = scanl1 (\(_,q) (y,s') -> (y, s'+q)) xs       -- cumulative weight
+    p <- liftM toRational $ getRandomR (0.0,s)
+    return . fst . head $ dropWhile (\(_,q) -> q < p) cs
 
--- | Sample a value from a uniform distribution of a list of elements.
-uniform :: (MonadRandom m) => [a] -> m a
-uniform = fromList . fmap (flip (,) 1)
+-- | Sample a value from a uniform distribution of a Foldable of elements.
+uniform :: (F.Foldable t, MonadRandom m) => t a -> m a
+uniform = fromList . fmap (flip (,) 1) . F.toList
 
--- | Sample a value from a uniform distribution of a list of elements if that list is not empty.
-uniformMay :: (MonadRandom m) => [a] -> m (Maybe a)
-uniformMay [] = return Nothing
-uniformMay xs = liftM Just (uniform xs)
+-- | Sample a value from a uniform distribution of a Foldable of elements if it is not empty.
+uniformMay :: (F.Foldable t, MonadRandom m) => t a -> m (Maybe a)
+uniformMay xs = if F.foldr (\_ _ -> False) True xs
+  then return Nothing
+  else liftM Just (uniform xs)
 
 instance (MonadRandom m) => MonadRandom (IdentityT m) where
     getRandom = lift getRandom


### PR DESCRIPTION
You might want to sample from a Set, say. This does not litter the namespace further, so I think it should be an automatic improvement? The comments might be improvable. In the next major version bump, you might want to change fromList's name ("sample"?) and empty list error.
