### PR TITLE
Bump the upper bound for transformers-compat dependency

### DIFF
--- a/MonadRandom.cabal
+++ b/MonadRandom.cabal
@@ -34,7 +34,7 @@ library
   build-depends:
     base                >=2   && <5,
     transformers        >=0.3 && <0.6,
-    transformers-compat >=0.4 && <0.6,
+    transformers-compat >=0.4 && <0.6.1,
     mtl                 >=2.1 && <2.3,
     primitive           >=0.6 && <0.7,
     fail                >=4.9        ,


### PR DESCRIPTION
Confirmed that it build fine with `transformers-compat-0.6.0.6`.