### PR TITLE
Compatibility with random-1.2

### DIFF
--- a/Control/Monad/Random/Class.hs
+++ b/Control/Monad/Random/Class.hs
@@ -66,7 +66,7 @@ import qualified Control.Monad.Trans.State.Lazy    as LazyState
 import qualified Control.Monad.Trans.State.Strict  as StrictState
 import qualified Control.Monad.Trans.Writer.Lazy   as LazyWriter
 import qualified Control.Monad.Trans.Writer.Strict as StrictWriter
-import           System.Random
+import qualified System.Random                     as Random
 
 import qualified Data.Foldable                     as F
 
@@ -91,7 +91,7 @@ class (Monad m) => MonadRandom m where
   -- interval.
   --
   -- See 'System.Random.randomR' for details.
-  getRandomR :: (Random a) => (a, a) -> m a
+  getRandomR :: (Random.Random a) => (a, a) -> m a
 
   -- | The same as 'getRandomR', but using a default range determined by the type:
   --
@@ -104,25 +104,25 @@ class (Monad m) => MonadRandom m where
   -- * For 'Integer', the range is (arbitrarily) the range of 'Int'.
   --
   -- See 'System.Random.random' for details.
-  getRandom :: (Random a) => m a
+  getRandom :: (Random.Random a) => m a
 
   -- | Plural variant of 'getRandomR', producing an infinite list of
   -- random values instead of returning a new generator.
   --
   -- See 'System.Random.randomRs' for details.
-  getRandomRs :: (Random a) => (a, a) -> m [a]
+  getRandomRs :: (Random.Random a) => (a, a) -> m [a]
 
   -- | Plural variant of 'getRandom', producing an infinite list of
   -- random values instead of returning a new generator.
   --
   -- See 'System.Random.randoms' for details.
-  getRandoms :: (Random a) => m [a]
+  getRandoms :: (Random.Random a) => m [a]
 
 instance MonadRandom IO where
-  getRandomR       = randomRIO
-  getRandom        = randomIO
-  getRandomRs lohi = liftM (randomRs lohi) newStdGen
-  getRandoms       = liftM randoms newStdGen
+  getRandomR       = Random.randomRIO
+  getRandom        = Random.randomIO
+  getRandomRs lohi = liftM (Random.randomRs lohi) Random.newStdGen
+  getRandoms       = liftM Random.randoms Random.newStdGen
 
 instance (MonadRandom m) => MonadRandom (ContT r m) where
   getRandomR  = lift . getRandomR
@@ -221,8 +221,8 @@ class (Monad m) => MonadSplit g m | m -> g where
   -- See 'System.Random.split' for details.
   getSplit :: m g
 
-instance MonadSplit StdGen IO where
-  getSplit = newStdGen
+instance MonadSplit Random.StdGen IO where
+  getSplit = Random.newStdGen
 
 instance (MonadSplit g m) => MonadSplit g (ContT r m) where
   getSplit = lift getSplit

--- a/Control/Monad/Random/Lazy.hs
+++ b/Control/Monad/Random/Lazy.hs
@@ -44,7 +44,7 @@ module Control.Monad.Random.Lazy
       module Control.Monad.Trans,
     ) where
 
-import           System.Random
+import           System.Random hiding (uniform, uniformR)
 
 import           Control.Monad.Random.Class
 

--- a/Control/Monad/Random/Strict.hs
+++ b/Control/Monad/Random/Strict.hs
@@ -42,7 +42,7 @@ module Control.Monad.Random.Strict
       module Control.Monad.Trans,
     ) where
 
-import           System.Random
+import           System.Random hiding (uniform, uniformR)
 
 import           Control.Monad.Random.Class
 

--- a/MonadRandom.cabal
+++ b/MonadRandom.cabal
@@ -32,7 +32,7 @@ library
     transformers-compat >=0.4 && <0.7,
     mtl                 >=2.1 && <2.3,
     primitive           >=0.6 && <0.8,
-    random              >=1.0 && <1.2
+    random              >=1.0 && <1.3
   ghc-options:         -Wall
   default-language:    Haskell2010
 


### PR DESCRIPTION
Here is a minimal change that is required to compile it with the new version of random.

There is a bit more that can be done in order to integrate with new features, but I think we can postpone to a separate PR. Here is a potential instance for the new `StatefulGen` class.

```haskell
data RandGenM g = RandGenM

instance (Monad m, RandomGen g) => StatefulGen (RandGenM g) (RandT g m) where
  uniformWord32R r = applyRand (genWord32R r)
  uniformWord64R r = applyRand (genWord64R r)
  uniformWord8 = applyRand genWord8
  uniformWord16 = applyRand genWord16
  uniformWord32 = applyRand genWord32
  uniformWord64 = applyRand genWord64
  uniformShortByteString n = applyRand (genShortByteString n)

instance (Monad m, RandomGen g) => RandomGenM (RandGenM g) g (RandT g m) where
  applyRandomGenM = applyRand

applyRand :: Applicative m => (g -> (a, g)) -> RandGenM g -> RandT g m a
applyRand f _ = liftRandT (pure . f)
```