### PR TITLE
Add `StatefulGen` instances

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,10 @@
+0.5.3 (xx xxxx 2021)
+--------------------
+
+- `StatefulGen` instances for `RandT`
+- Addition of `RandGen`
+- Additioon of `withRandGen` and `withRandGen_`
+
 0.5.2 (24 June 2020)
 --------------------
 

--- a/Control/Monad/Trans/Random/Lazy.hs
+++ b/Control/Monad/Trans/Random/Lazy.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
@@ -71,8 +72,11 @@ import           Control.Monad.Trans.Class
 import qualified Control.Monad.Trans.State.Lazy as LazyState
 import           Control.Monad.Trans.Random.Strict (RandGen(..))
 import           Data.Functor.Identity
+#if MIN_VERSION_random(1,2,0)
 import           System.Random.Stateful
-
+#else
+import           System.Random
+#endif
 -- | A random monad parameterized by the type @g@ of the generator to carry.
 --
 -- The 'return' function leaves the generator unchanged, while '>>=' uses the
@@ -266,6 +270,7 @@ evalRandIO t = liftM (evalRand t) newStdGen
 evalRandTIO :: (MonadIO m) => RandT StdGen m a -> m a
 evalRandTIO t = liftIO newStdGen >>= evalRandT t
 
+#if MIN_VERSION_random(1,2,0)
 -- |
 --
 -- @since 0.5.3
@@ -286,7 +291,7 @@ instance (Monad m, RandomGen g) => RandomGenM (RandGen g) g (RandT g m) where
 
 applyRandT :: Applicative m => (g -> (a, g)) -> RandGen g -> RandT g m a
 applyRandT f _ = liftRandT (pure . f)
-
+#endif
 
 -- | A `RandT` runner that allows using it with `StatefulGen` restricted actions. Returns
 -- the outcome of random computation and the new pseudo-random-number generator

--- a/Control/Monad/Trans/Random/Lazy.hs
+++ b/Control/Monad/Trans/Random/Lazy.hs
@@ -46,6 +46,10 @@ module Control.Monad.Trans.Random.Lazy
     liftListen,
     liftPass,
     evalRandTIO,
+    -- * StatefulGen interface
+    RandGen(..),
+    withRandGen,
+    withRandGen_,
     -- * Examples
     -- ** Random monads
     -- $examples
@@ -65,8 +69,9 @@ import           Control.Monad.RWS.Class
 import           Control.Monad.Signatures
 import           Control.Monad.Trans.Class
 import qualified Control.Monad.Trans.State.Lazy as LazyState
+import           Control.Monad.Trans.Random.Strict (RandGen(..))
 import           Data.Functor.Identity
-import           System.Random
+import           System.Random.Stateful
 
 -- | A random monad parameterized by the type @g@ of the generator to carry.
 --
@@ -260,6 +265,59 @@ evalRandIO t = liftM (evalRand t) newStdGen
 -- computation.
 evalRandTIO :: (MonadIO m) => RandT StdGen m a -> m a
 evalRandTIO t = liftIO newStdGen >>= evalRandT t
+
+-- |
+--
+-- @since 0.5.3
+instance (Monad m, RandomGen g) => StatefulGen (RandGen g) (RandT g m) where
+  uniformWord32R r = applyRandT (genWord32R r)
+  uniformWord64R r = applyRandT (genWord64R r)
+  uniformWord8 = applyRandT genWord8
+  uniformWord16 = applyRandT genWord16
+  uniformWord32 = applyRandT genWord32
+  uniformWord64 = applyRandT genWord64
+  uniformShortByteString n = applyRandT (genShortByteString n)
+
+-- |
+--
+-- @since 0.5.3
+instance (Monad m, RandomGen g) => RandomGenM (RandGen g) g (RandT g m) where
+  applyRandomGenM = applyRandT
+
+applyRandT :: Applicative m => (g -> (a, g)) -> RandGen g -> RandT g m a
+applyRandT f _ = liftRandT (pure . f)
+
+
+-- | A `RandT` runner that allows using it with `StatefulGen` restricted actions. Returns
+-- the outcome of random computation and the new pseudo-random-number generator
+--
+-- >>> withRandGen (mkStdGen 2021) uniformM :: IO (Int, StdGen)
+-- (6070831465987696718,StdGen {unStdGen = SMGen 4687568268719557181 4805600293067301895})
+--
+-- @since 0.5.3
+withRandGen ::
+     g
+  -- ^ initial generator
+  -> (RandGen g -> RandT g m a)
+  -> m (a, g)
+  -- ^ return value and final generator
+withRandGen g action = runRandT (action RandGen) g
+
+-- | Same as `withRandGen`, but discards the resulting generator.
+--
+-- >>> withRandGen_ (mkStdGen 2021) uniformM :: IO Int
+-- 6070831465987696718
+--
+-- @since 0.5.3
+withRandGen_ ::
+     Monad m
+  => g
+  -- ^ initial generator
+  -> (RandGen g -> RandT g m a)
+  -> m a
+  -- ^ return value and final generator
+withRandGen_ g action = evalRandT (action RandGen) g
+
 
 {- $examples
 

--- a/Control/Monad/Trans/Random/Strict.hs
+++ b/Control/Monad/Trans/Random/Strict.hs
@@ -47,6 +47,10 @@ module Control.Monad.Trans.Random.Strict
     liftCatch,
     liftListen,
     liftPass,
+    -- * StatefulGen interface
+    RandGen(..),
+    withRandGen,
+    withRandGen_,
     -- * Examples
     -- ** Random monads
     -- $examples
@@ -67,7 +71,7 @@ import           Control.Monad.Signatures
 import           Control.Monad.Trans.Class
 import qualified Control.Monad.Trans.State.Strict as StrictState
 import           Data.Functor.Identity
-import           System.Random
+import           System.Random.Stateful
 
 -- | A random monad parameterized by the type @g@ of the generator to carry.
 --
@@ -261,6 +265,66 @@ evalRandIO t = liftM (evalRand t) newStdGen
 -- computation.
 evalRandTIO :: (MonadIO m) => RandT StdGen m a -> m a
 evalRandTIO t = liftIO newStdGen >>= evalRandT t
+
+
+-- | A proxy that carries information about the type of generator to use with @RandT@
+-- monad and its `StatefulGen` instance.
+--
+-- @since 0.5.3
+data RandGen g = RandGen
+
+-- |
+--
+-- @since 0.5.3
+instance (Monad m, RandomGen g) => StatefulGen (RandGen g) (RandT g m) where
+  uniformWord32R r = applyRandT (genWord32R r)
+  uniformWord64R r = applyRandT (genWord64R r)
+  uniformWord8 = applyRandT genWord8
+  uniformWord16 = applyRandT genWord16
+  uniformWord32 = applyRandT genWord32
+  uniformWord64 = applyRandT genWord64
+  uniformShortByteString n = applyRandT (genShortByteString n)
+
+-- |
+--
+-- @since 0.5.3
+instance (Monad m, RandomGen g) => RandomGenM (RandGen g) g (RandT g m) where
+  applyRandomGenM = applyRandT
+
+applyRandT :: Applicative m => (g -> (a, g)) -> RandGen g -> RandT g m a
+applyRandT f _ = liftRandT (pure . f)
+
+
+-- | A `RandT` runner that allows using it with `StatefulGen` restricted actions. Returns
+-- the outcome of random computation and the new pseudo-random-number generator
+--
+-- >>> withRandGen (mkStdGen 2021) uniformM :: IO (Int, StdGen)
+-- (6070831465987696718,StdGen {unStdGen = SMGen 4687568268719557181 4805600293067301895})
+--
+-- @since 0.5.3
+withRandGen ::
+     g
+  -- ^ initial generator
+  -> (RandGen g -> RandT g m a)
+  -> m (a, g)
+  -- ^ return value and final generator
+withRandGen g action = runRandT (action RandGen) g
+
+-- | Same as `withRandGen`, but discards the resulting generator.
+--
+-- >>> withRandGen_ (mkStdGen 2021) uniformM :: IO Int
+-- 6070831465987696718
+--
+-- @since 0.5.3
+withRandGen_ ::
+     Monad m
+  => g
+  -- ^ initial generator
+  -> (RandGen g -> RandT g m a)
+  -> m a
+  -- ^ return value and final generator
+withRandGen_ g action = evalRandT (action RandGen) g
+
 
 {- $examples
 

--- a/Control/Monad/Trans/Random/Strict.hs
+++ b/Control/Monad/Trans/Random/Strict.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
@@ -71,7 +72,11 @@ import           Control.Monad.Signatures
 import           Control.Monad.Trans.Class
 import qualified Control.Monad.Trans.State.Strict as StrictState
 import           Data.Functor.Identity
+#if MIN_VERSION_random(1,2,0)
 import           System.Random.Stateful
+#else
+import           System.Random
+#endif
 
 -- | A random monad parameterized by the type @g@ of the generator to carry.
 --
@@ -273,6 +278,7 @@ evalRandTIO t = liftIO newStdGen >>= evalRandT t
 -- @since 0.5.3
 data RandGen g = RandGen
 
+#if MIN_VERSION_random(1,2,0)
 -- |
 --
 -- @since 0.5.3
@@ -293,7 +299,7 @@ instance (Monad m, RandomGen g) => RandomGenM (RandGen g) g (RandT g m) where
 
 applyRandT :: Applicative m => (g -> (a, g)) -> RandGen g -> RandT g m a
 applyRandT f _ = liftRandT (pure . f)
-
+#endif
 
 -- | A `RandT` runner that allows using it with `StatefulGen` restricted actions. Returns
 -- the outcome of random computation and the new pseudo-random-number generator

--- a/MonadRandom.cabal
+++ b/MonadRandom.cabal
@@ -1,5 +1,5 @@
 name:                MonadRandom
-version:             0.5.2
+version:             0.5.3
 synopsis:            Random-number generation monad.
 description:         Support for computations which consume random values.
 license:             BSD3


### PR DESCRIPTION
I promised in https://github.com/byorgey/MonadRandom/pull/46#issuecomment-648999975 to add those instances. 

When  I said "next week", I guess I meant next year :wink: I guess it is better later than never.

The whole point of this PR is that for anyone who uses the new stateful monadic style interface of `random` will also be able to use it with `RandT. For example if someone writes a function:

```haskell
randomUuid :: StatefulGen g m => g -> m Uuid
```

The will now be able to pass it to `withRandGen` and thus use it with `RandT` and `RandomGen` generators.