### PR TITLE
Require random >= 1.0.1

### DIFF
--- a/MonadRandom.cabal
+++ b/MonadRandom.cabal
@@ -32,7 +32,7 @@ library
     transformers-compat >=0.4 && <0.8,
     mtl                 >=2.2.1 && <2.3 || >= 2.3.1 && < 2.4,
     primitive           >=0.6 && <0.8,
-    random              >=1.0 && <1.3
+    random              >=1.0.1 && <1.3
   ghc-options:         -Wall
   default-language:    Haskell2010
   other-extensions:    Safe


### PR DESCRIPTION
`random-1.0.0.*` are not `Safe`, breaking compilation of `MonadRandom`.

As a Hackage trustee I made appropriate revisions.